### PR TITLE
Add a tip about different git config files

### DIFF
--- a/src/tools/git.adoc
+++ b/src/tools/git.adoc
@@ -19,3 +19,25 @@ Learn about `git add --patch`, `git reset`, and `git commit --amend`.
 
 Become friends with `git rebase -i` and never merge _master_ into
 your feature branch again.
+
+[TIP]
+===============================
+In case you have your personal email set up in the global git config (`git config --global --list`), you can override it by including config file based on the current git directory.
+
+global config `~/.gitconfig`
+```
+[user]
+     name = Joe Srna
+     email = joe.srna@gmail.com
+[includeIf "gitdir:~/Projects/vacuumlabs/"]
+    path = ~/Projects/vacuumlabs/.gitconfig
+```
+
+work related config `~/Projects/vacuumlabs/.gitconfig`
+```
+[user]
+     email = joe.srna@vacuumlabs.com
+```
+
+You can verify the change by running `git config --list` within different directories.
+===============================


### PR DESCRIPTION
While I was browsing (git) logs of various repositories I noticed that authors use their private emails for their work related commits.

Tip shows authors that there is a simple way how to configure git client so when they work on *work related* projects proper email is used instead of the personal one.

--- 

Not really sure if the whole thing belongs in the `TIP` block. When I started I just wanted to add a paragraph but later on it felt empty and not finished - without an example.