### PR TITLE
Add a note to gitconfig files tip

### DIFF
--- a/src/tools/git.adoc
+++ b/src/tools/git.adoc
@@ -39,5 +39,5 @@ work related config `~/Projects/vacuumlabs/.gitconfig`
      email = joe.srna@vacuumlabs.com
 ```
 
-You can verify the change by running `git config --list` within different directories.
+You can verify the change by running `git config --list` within different directories. Keep in mind, that this will work correctly only in directories containing a git repository. For more information about conditional includes, visit https://git-scm.com/docs/git-config#_conditional_includes[official documentation^].
 ===============================


### PR DESCRIPTION
When I was testing split config file feature, I failed to verify that config works, because i was not testing from a git repo directory. This note helps others to avoid making the same mistake