### PR TITLE
Fixed Django tutorial link

### DIFF
--- a/src/tutorials/index.adoc
+++ b/src/tutorials/index.adoc
@@ -14,7 +14,7 @@ link:http://facebook.github.io/react/[React] and link:http://redux.js.org[Redux]
 
 Learning Python::
 We use link:http://www.diveintopython3.net[Python3] with Django.
-Have a look at this great link:http://gettingstartedwithdjango.com[Django tutorial].
+Have a look at this great link:http://www.gettingstartedwithdjango.com[Django tutorial].
 
 Clojure intro::
 http://www.braveclojure.com/foreword/


### PR DESCRIPTION
Django tutorial link does not work without `www`.

Fix for #8.